### PR TITLE
install: change install path to a dedicated location

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+scibian-hpc-netboot (0.8sci9-1) scibian9; urgency=medium
+
+  * Add a hpc-netboot sub-directory under /var/www/
+
+ -- Guillaume Ranquet <guillaume-externe.ranquet@edf.fr>  Wed, 16 Dec 2020 16:06:29 +0100
+
 scibian-hpc-netboot (0.8sci9) scibian9; urgency=medium
 
   * Set default boot menu to kernel 4.9.0-12

--- a/debian/scibian-hpc-netboot-menu.install
+++ b/debian/scibian-hpc-netboot-menu.install
@@ -1,2 +1,2 @@
 conf/menu etc/scibian-hpc-netboot
-scripts/bootmenu.py var/www/cgi-bin/scibian-hpc-netboot
+scripts/bootmenu.py var/www/hpc-netboot/cgi-bin/scibian-hpc-netboot

--- a/debian/scibian-hpc-netboot-preseedator.install
+++ b/debian/scibian-hpc-netboot-preseedator.install
@@ -1,3 +1,3 @@
 conf/installer etc/scibian-hpc-netboot
-scripts/preseedator.py var/www/cgi-bin/scibian-hpc-netboot
-scripts/partitioner.py var/www/cgi-bin/scibian-hpc-netboot
+scripts/preseedator.py var/www/hpc-netboot/cgi-bin/scibian-hpc-netboot
+scripts/partitioner.py var/www/hpc-netboot/cgi-bin/scibian-hpc-netboot


### PR DESCRIPTION
Change the install path to a dedicated location for the netboot-hpc package to avoid any
 chance of file/namespace colision/permission issues on the apache web server.